### PR TITLE
added react-native-web support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ import { getStatusBarHeight } from 'react-native-status-bar-height';
 // 44 - on iPhoneX
 // 20 - on iOS device
 // X - on Android platfrom (runtime value)
+// 0 - on all other platforms (default)
 console.log(getStatusBarHeight());
 
 // will be 0 on Android, because You pass true to skipAndroid

--- a/index.js
+++ b/index.js
@@ -15,14 +15,22 @@ if (Platform.OS === 'ios' && !Platform.isPad && !Platform.isTVOS) {
     isIPhoneX = W_WIDTH === X_WIDTH && W_HEIGHT === X_HEIGHT || W_WIDTH === XSMAX_WIDTH && W_HEIGHT === XSMAX_HEIGHT;
 }
 
-export function getStatusBarHeight(skipAndroid: boolean = false) {
-    if (Platform.OS === 'ios') {
-        return isIPhoneX ? 44 : 20;
-    }
+function getIPhoneStatusBarHeight() {
+    return isIPhoneX ? 44 : 20;
+}
 
-    if (skipAndroid) {
+function getAndroidStatusBarHeight(skip: boolean) {
+    if (skip) {
         return 0;
     }
 
     return StatusBar.currentHeight;
+}
+
+export function getStatusBarHeight(skipAndroid: boolean = false) {
+    return Platform.select({
+        ios: getIPhoneStatusBarHeight(),
+        android: getAndroidStatusBarHeight(skipAndroid),
+        default: 0
+    })
 }


### PR DESCRIPTION
This module currently does not work with other platforms than `ios` and `android`. To support them `react-native` has a `default` platform which means all platforms not specified.

This PR adds `0` as default value and a nice `Platform.select` to easier support new platforms in future.