### PR TITLE
removed deprecated expo variables. fixes #23

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,5 +6,4 @@ declare module 'react-native-status-bar-height' {
     export function isIPhone12(): boolean
     export function isIPhone12Max(): boolean
     export function isIPhoneWithMonobrow(): boolean
-    export function isExpo(): boolean;
 }

--- a/index.js
+++ b/index.js
@@ -52,10 +52,6 @@ export const isIPhone12 = () => isIPhone12_v;
 export const isIPhone12Max = () => isIPhone12Max_v;
 export const isIPhoneWithMonobrow = () => isIPhoneWithMonobrow_v;
 
-const getExpoRoot = () => global.Expo || global.__expo || global.__exponent;
-
-export const isExpo = () => getExpoRoot() !== undefined;
-
 export function getStatusBarHeight(skipAndroid) {
   return Platform.select({
     ios: statusBarHeight,

--- a/index.js.flow
+++ b/index.js.flow
@@ -6,5 +6,4 @@ declare module 'react-native-status-bar-height' {
     declare function isIPhone12(): boolean
     declare function isIPhone12Max(): boolean
     declare function isIPhoneWithMonobrow(): boolean
-    declare function isExpo(): boolean
 }


### PR DESCRIPTION
getExpoRoot and isExpo are not being in used in this library. Also these expo variables are deprecated anyway. I also don't think that the exported isExpo function in relevant to this library. (isExpo in not even documented on this library's documentation too.)

Since no one addressing this issue or fixing it. I think I'll leave the PR here. Rest is up to the maintainer. :) 